### PR TITLE
Fix: failed parse two url function in same line

### DIFF
--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -114,7 +114,7 @@ var macros = map[string]string{
 	"num":        `[0-9]*\.[0-9]+|[0-9]+`,
 	"string":     `"(?:{stringchar}|')*"|'(?:{stringchar}|")*'`,
 	"stringchar": `{urlchar}|[ ]|\\{nl}`,
-	"urlchar":    "[\u0009\u0021\u0023-\u0026\u0027-\u007E]|{nonascii}|{escape}",
+	"urlchar":    "[\u0009\u0021\u0023-\u0028\u002A-\u007E]|{nonascii}|{escape}",
 	"nl":         `[\n\r\f]|\r\n`,
 	"w":          `{wc}*`,
 	"wc":         `[\t\n\f\r ]`,

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -4,9 +4,7 @@
 
 package scanner
 
-import (
-	"testing"
-)
+import "testing"
 
 func TestMatchers(t *testing.T) {
 	// Just basic checks, not exhaustive at all.
@@ -55,4 +53,7 @@ func TestMatchers(t *testing.T) {
 	checkMatch("{", TokenChar, "{")
 	checkMatch("\uFEFF", TokenBOM, "\uFEFF")
 	checkMatch(`╯︵┻━┻"stuff"`, TokenIdent, "╯︵┻━┻", TokenString, `"stuff"`)
+	// url(1.png)url(2.png) seems unlike exist in valid css, but also failed when
+	//   .A{background:url(1.png);}.B{background:url(2.png);}
+	checkMatch("url(1.png)url(2.png)", TokenURI, "url(1.png)", TokenURI, "url(2.png)")
 }


### PR DESCRIPTION
Normally a css file do not contain two url() functions in a line, but in
a minimized css file it is not true.
