### PR TITLE
Remove CR and FF that wouldn't appear after preprocessing.

### DIFF
--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -236,7 +236,7 @@ func (s *Scanner) Next() *Token {
 	// shortcut before testing multiple regexps.
 	input := s.input[s.pos:]
 	switch input[0] {
-	case '\t', '\n', '\f', '\r', ' ':
+	case '\t', '\n', ' ':
 		// Whitespace.
 		return s.emitToken(TokenS, matchers[TokenS].FindString(input))
 	case '.':


### PR DESCRIPTION
Follow up to #16. Cleanup dead code (unreachable now that preprocessing replaces those bytes).